### PR TITLE
support toml config files(used by potatso 2 )

### DIFF
--- a/Potatso.xcodeproj/project.pbxproj
+++ b/Potatso.xcodeproj/project.pbxproj
@@ -17,6 +17,18 @@
 		1EEBB8781FFFD52700EB33C3 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EEBB8761FFFD4B500EB33C3 /* NetworkExtension.framework */; };
 		1EEBB8791FFFD8A700EB33C3 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EEBB8761FFFD4B500EB33C3 /* NetworkExtension.framework */; };
 		1EF602951F113A660005E0C7 /* GeoLite2-Country.mmdb in Resources */ = {isa = PBXBuildFile; fileRef = 1EF602941F113A660005E0C7 /* GeoLite2-Country.mmdb */; };
+		274BFE1C209F7577009C0189 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFDFF209F7577009C0189 /* Date.swift */; };
+		274BFE1D209F7577009C0189 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE00209F7577009C0189 /* Lexer.swift */; };
+		274BFE1E209F7577009C0189 /* Serialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE01209F7577009C0189 /* Serialize.swift */; };
+		274BFE1F209F7577009C0189 /* Evaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE02209F7577009C0189 /* Evaluator.swift */; };
+		274BFE20209F7577009C0189 /* Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE03209F7577009C0189 /* Tokens.swift */; };
+		274BFE21209F7577009C0189 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE04209F7577009C0189 /* Helpers.swift */; };
+		274BFE22209F7577009C0189 /* Toml.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE05209F7577009C0189 /* Toml.swift */; };
+		274BFE23209F7577009C0189 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE06209F7577009C0189 /* Path.swift */; };
+		274BFE24209F7577009C0189 /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE07209F7577009C0189 /* Regex.swift */; };
+		274BFE25209F7577009C0189 /* Grammar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE08209F7577009C0189 /* Grammar.swift */; };
+		274BFE26209F7577009C0189 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE09209F7577009C0189 /* String.swift */; };
+		274BFE27209F7577009C0189 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274BFE0A209F7577009C0189 /* Parser.swift */; };
 		3880684779850530AFBD4C88 /* Pods_PacketTunnel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A478ADBAAA1661B3FB51E4D3 /* Pods_PacketTunnel.framework */; };
 		3A104BCE2073C55D00C848D5 /* libsodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A104BB92073C4AB00C848D5 /* libsodium.framework */; };
 		3A104BCF2073C55D00C848D5 /* libuv.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A104BC22073C4CD00C848D5 /* libuv.framework */; };
@@ -651,6 +663,18 @@
 		1EF602941F113A660005E0C7 /* GeoLite2-Country.mmdb */ = {isa = PBXFileReference; lastKnownFileType = file; path = "GeoLite2-Country.mmdb"; sourceTree = "<group>"; };
 		217DDEB43D39CFD980088F46 /* Pods-PotatsoModel.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PotatsoModel.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PotatsoModel/Pods-PotatsoModel.debug.xcconfig"; sourceTree = "<group>"; };
 		2589D04E6C48F30ED63BA84F /* Pods_PotatsoModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PotatsoModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		274BFDFF209F7577009C0189 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		274BFE00209F7577009C0189 /* Lexer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lexer.swift; sourceTree = "<group>"; };
+		274BFE01209F7577009C0189 /* Serialize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serialize.swift; sourceTree = "<group>"; };
+		274BFE02209F7577009C0189 /* Evaluator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Evaluator.swift; sourceTree = "<group>"; };
+		274BFE03209F7577009C0189 /* Tokens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tokens.swift; sourceTree = "<group>"; };
+		274BFE04209F7577009C0189 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
+		274BFE05209F7577009C0189 /* Toml.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Toml.swift; sourceTree = "<group>"; };
+		274BFE06209F7577009C0189 /* Path.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
+		274BFE07209F7577009C0189 /* Regex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Regex.swift; sourceTree = "<group>"; };
+		274BFE08209F7577009C0189 /* Grammar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Grammar.swift; sourceTree = "<group>"; };
+		274BFE09209F7577009C0189 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		274BFE0A209F7577009C0189 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		2AE5B01A5E9CF50CB9760E6E /* Pods-PacketTunnel.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PacketTunnel.release.xcconfig"; path = "Pods/Target Support Files/Pods-PacketTunnel/Pods-PacketTunnel.release.xcconfig"; sourceTree = "<group>"; };
 		3A104BB32073C4AB00C848D5 /* libsodium.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libsodium.xcodeproj; path = Library/ssrNative/depends/libsodium/ios/libsodium.xcodeproj; sourceTree = SOURCE_ROOT; };
 		3A104BBC2073C4CD00C848D5 /* libuv.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = libuv.xcodeproj; path = Library/ssrNative/depends/libuv/ios/libuv.xcodeproj; sourceTree = SOURCE_ROOT; };
@@ -1353,6 +1377,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		274BFDFE209F7577009C0189 /* Toml */ = {
+			isa = PBXGroup;
+			children = (
+				274BFDFF209F7577009C0189 /* Date.swift */,
+				274BFE00209F7577009C0189 /* Lexer.swift */,
+				274BFE01209F7577009C0189 /* Serialize.swift */,
+				274BFE02209F7577009C0189 /* Evaluator.swift */,
+				274BFE03209F7577009C0189 /* Tokens.swift */,
+				274BFE04209F7577009C0189 /* Helpers.swift */,
+				274BFE05209F7577009C0189 /* Toml.swift */,
+				274BFE06209F7577009C0189 /* Path.swift */,
+				274BFE07209F7577009C0189 /* Regex.swift */,
+				274BFE08209F7577009C0189 /* Grammar.swift */,
+				274BFE09209F7577009C0189 /* String.swift */,
+				274BFE0A209F7577009C0189 /* Parser.swift */,
+			);
+			path = Toml;
+			sourceTree = "<group>";
+		};
 		360FC4CAA2A2878A46E847E5 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1684,6 +1727,7 @@
 				9BC215CB1CB5E584002AADD1 /* Manager.swift */,
 				9BF3034C1CCA20D80096588E /* Logging.swift */,
 				9BC215C61CB51148002AADD1 /* Config.swift */,
+				274BFDFE209F7577009C0189 /* Toml */,
 				9BB3F73E1CC60B5300C2DD05 /* Image.swift */,
 				9B9B15C11C21595B000B6541 /* Info.plist */,
 				B82574A81D1D98CF007BAF40 /* Pollution.swift */,
@@ -3660,10 +3704,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BF3034D1CCA20D80096588E /* Logging.swift in Sources */,
+				274BFE1D209F7577009C0189 /* Lexer.swift in Sources */,
+				274BFE1E209F7577009C0189 /* Serialize.swift in Sources */,
+				274BFE24209F7577009C0189 /* Regex.swift in Sources */,
+				274BFE20209F7577009C0189 /* Tokens.swift in Sources */,
+				274BFE21209F7577009C0189 /* Helpers.swift in Sources */,
+				274BFE1C209F7577009C0189 /* Date.swift in Sources */,
 				9BC215CC1CB5E584002AADD1 /* Manager.swift in Sources */,
+				274BFE25209F7577009C0189 /* Grammar.swift in Sources */,
 				9BB3F7411CC60B5300C2DD05 /* Image.swift in Sources */,
 				B82574A91D1D98CF007BAF40 /* Pollution.swift in Sources */,
+				274BFE22209F7577009C0189 /* Toml.swift in Sources */,
+				274BFE23209F7577009C0189 /* Path.swift in Sources */,
 				9BC215C71CB51148002AADD1 /* Config.swift in Sources */,
+				274BFE26209F7577009C0189 /* String.swift in Sources */,
+				274BFE27209F7577009C0189 /* Parser.swift in Sources */,
+				274BFE1F209F7577009C0189 /* Evaluator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Potatso/Base.lproj/Localizable.strings
+++ b/Potatso/Base.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "qrcode.album" = "Album";
 
 
+"%d ms" = "%d ms";
 "%d rule" = "%d rule";
 "%d rules" = "%d rules";
 "Action" = "Action";
@@ -65,6 +66,7 @@
 "Host can't be empty" = "Host can't be empty";
 "IP Rules Match" = "IP Rules Match";
 "Import Config From URL" = "Import Config From URL";
+"Import Config In Potatso 2 Format" = "Import Config In Potatso 2 Format";
 "Import From QRCode" = "Import From QRCode";
 "Import From URL" = "Import From URL";
 "Import Success" = "Import Success";

--- a/Potatso/Core/Importer.swift
+++ b/Potatso/Core/Importer.swift
@@ -132,3 +132,40 @@ struct Importer {
     }
 
 }
+
+///custom modify: for toml
+extension Importer {
+    func importTomlConfigFromUrl() {
+        var urlTextField: UITextField?
+        let alert = UIAlertController(title: "Import Config In Potatso 2 Format".localized(), message: nil, preferredStyle: .alert)
+        alert.addTextField { (textField) in
+            textField.placeholder = "Input URL".localized()
+            urlTextField = textField
+        }
+        alert.addAction(UIAlertAction(title: "OK".localized(), style: .default, handler: { (action) in
+            if let input = urlTextField?.text, input.hasPrefix("http") {
+                self.importTomlConfig(input)
+            }
+        }))
+        alert.addAction(UIAlertAction(title: "CANCEL".localized(), style: .cancel, handler: nil))
+        viewController?.present(alert, animated: true, completion: nil)
+    }
+    
+    func importTomlConfig(_ source: String) {
+        viewController?.showProgreeHUD("Importing Config...".localized())
+        Async.background(after: 1) {
+            let config = Config()
+            do {
+                if let url = URL(string: source) {
+                    ///custom modify: remove for Windows
+                    let conf = try String(contentsOf: url).replacingOccurrences(of: "\r\n", with: "\n")
+                    try config.setupToml(conf)
+                }
+                self.onConfigSaveCallback(true, error: nil)
+            } catch {
+                self.onConfigSaveCallback(false, error: error)
+            }
+        }
+    }
+
+}

--- a/Potatso/More/SettingsViewController.swift
+++ b/Potatso/More/SettingsViewController.swift
@@ -81,6 +81,14 @@ class SettingsViewController: FormViewController, MFMailComposeViewControllerDel
                 let importer = Importer(vc: self)
                 importer.importConfigFromUrl()
             })
+            ///custom modify: for toml format config
+            <<< ActionRow() {
+                $0.title = "Import Config in Potatso 2 Format".localized()
+                
+                }.onCellSelection({ [unowned self] (cell, row) -> () in
+                    let importer = Importer(vc: self)
+                    importer.importTomlConfigFromUrl()
+                })
             <<< ActionRow() {
                 $0.title = "Import From QRCode".localized()
             }.onCellSelection({ [unowned self] (cell, row) -> () in

--- a/Potatso/zh-Hans.lproj/Localizable.strings
+++ b/Potatso/zh-Hans.lproj/Localizable.strings
@@ -64,8 +64,9 @@
 "Home" = "首页";
 "Host" = "服务器";
 "Host can't be empty" = "服务器不能为空";
-"Import Config From URL" = "从 URL 导入配置";
 "IP Rules Match" = "IP 规则匹配";
+"Import Config From URL" = "从 URL 导入配置";
+"Import Config In Potatso 2 Format" = "从 URL 导入Potatso 2配置";
 "Import From QRCode" = "从二维码导入";
 "Import From URL" = "从 URL 导入";
 "Import Success" = "导入成功";

--- a/PotatsoLibrary/Config.swift
+++ b/PotatsoLibrary/Config.swift
@@ -113,3 +113,65 @@ open class Config {
     }
 
 }
+
+///custom modify: for toml
+extension Config {
+    public func setupToml(_ confStr: String) throws {
+        var proxiesConfig: [[String: AnyObject]] = []
+        
+        let toml = try Toml(withString: confStr)
+        for (_, table) in toml.tables("RULESET") {
+            if let name = table.string("name"),
+                name.count != 0,
+                let rules: [String] = table.array("rules"),
+                rules.count != 0 {
+                proxiesConfig.append(["name": name as AnyObject, "rules": rules as AnyObject])
+            }
+        }
+        
+        if !proxiesConfig.isEmpty {
+            realm.beginWrite()
+            try setupProxiesForToml()
+            try setupProxyRuleSetsForToml(proxiesConfig)
+            try setupConfigGroupsForToml()
+            try save()
+        }
+    }
+    
+    func setupProxiesForToml() throws {
+        //unimpelented
+//        if let proxiesConfig = configDict["proxies"] as? [[String: AnyObject]] {
+//            proxies = try proxiesConfig.map({ (config) -> Proxy? in
+//                return try Proxy(dictionary: config, inRealm: realm)
+//            }).filter { $0 != nil }.map { $0! }
+//            try proxies.forEach {
+//                try $0.validate(inRealm: realm)
+//                realm.add($0)
+//            }
+//        }
+    }
+    
+    func setupProxyRuleSetsForToml(_ proxiesConfig: [[String: AnyObject]]) throws {
+        ruleSets = try proxiesConfig.compactMap({ (config) -> ProxyRuleSet? in
+            return try ProxyRuleSet(dictionary: config, inRealm: realm)
+        })
+        try ruleSets.forEach {
+            try $0.validate(inRealm: realm)
+            realm.add($0)
+        }
+    }
+    
+    func setupConfigGroupsForToml() throws {
+        //unimpelented
+//        if let proxiesConfig = configDict["configGroups"] as? [[String: AnyObject]] {
+//            groups = try proxiesConfig.map({ (config) -> ConfigurationGroup? in
+//                return try ConfigurationGroup(dictionary: config, inRealm: realm)
+//            }).filter { $0 != nil }.map { $0! }
+//            try groups.forEach {
+//                try $0.validate(inRealm: realm)
+//                realm.add($0)
+//            }
+//        }
+    }
+    
+}

--- a/PotatsoLibrary/Toml/Date.swift
+++ b/PotatsoLibrary/Toml/Date.swift
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+private func buildDateFormatter(format: String) -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.dateFormat = format
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.calendar = Calendar(identifier: .iso8601)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    return formatter
+}
+
+private var rfc3339fractionalformatter =
+    buildDateFormatter(format: "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSSSSZZZZZ")
+
+private var rfc3339formatter: DateFormatter =
+    buildDateFormatter(format: "yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZZZ")
+
+private func localTimeOffset() -> String {
+    let totalSeconds: Int = TimeZone.current.secondsFromGMT()
+    let minutes: Int = (totalSeconds / 60) % 60
+    let hours: Int = totalSeconds / 3600
+    return String(format: "%02d%02d", hours, minutes)
+ }
+
+extension Date {
+    
+    // rfc3339 w fractional seconds w/ time offset
+    init?(rfc3339String: String, fractionalSeconds: Bool = true, localTime: Bool = false) {
+        var dateStr = rfc3339String
+        var dateFormatter: DateFormatter
+
+        if localTime {
+            dateStr += localTimeOffset()
+        }
+        
+        dateFormatter = fractionalSeconds ? rfc3339fractionalformatter : rfc3339formatter
+
+        if let d = dateFormatter.date(from: dateStr) {
+            self.init(timeInterval: 0, since: d)
+        } else {
+            return nil
+        }
+    }
+
+    func rfc3339String() -> String {
+        return rfc3339fractionalformatter.string(from: self)
+    }
+    
+}

--- a/PotatsoLibrary/Toml/Evaluator.swift
+++ b/PotatsoLibrary/Toml/Evaluator.swift
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/**
+    Class to evaluate input text with a regular expression and return tokens
+*/
+class Evaluator {
+    let regex: String
+    let generator: TokenGenerator
+    let push: [String]?
+    let pop: Bool
+    let multiline: Bool
+
+    init (regex: String, generator: @escaping TokenGenerator,
+          push: [String]? = nil, pop: Bool = false, multiline: Bool = false) {
+        self.regex = regex
+        self.generator = generator
+        self.push = push
+        self.pop = pop
+        self.multiline = multiline
+    }
+
+    func evaluate (_ content: String) throws ->
+        (token: Token?, index: String.Index)? {
+        var token: Token?
+        var index: String.Index
+
+        var options: NSRegularExpression.Options = []
+
+        if multiline {
+            options = [.dotMatchesLineSeparators]
+        }
+
+        if let m = content.match(self.regex, options: options) {
+            token = try self.generator(m)
+            index = content.index(content.startIndex, offsetBy: m.count)
+            return (token, index)
+        }
+
+        return nil
+    }
+}

--- a/PotatsoLibrary/Toml/Grammar.swift
+++ b/PotatsoLibrary/Toml/Grammar.swift
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+class Grammar {
+    var grammar = [String: [Evaluator]]()
+
+    init() {
+        grammar["comment"] = commentEvaluators()
+        grammar["string"] = stringEvaluators()
+        grammar["literalString"] = literalStringEvaluators()
+        grammar["multilineString"] = multiLineStringEvaluators()
+        grammar["multilineLiteralString"] = multiLineStringLiteralEvaluators()
+        grammar["tableName"] = tableNameEvaluators()
+        grammar["tableArray"] = tableArrayEvaluators()
+        grammar["value"] = valueEvaluators()
+        grammar["array"] = arrayEvaluators()
+        grammar["inlineTable"] = inlineTableEvaluators()
+        grammar["root"] = rootEvaluators()
+    }
+
+    private func commentEvaluators() -> [Evaluator] {
+        return [
+            Evaluator(regex: "[\r\n]", generator: { _ in nil }, pop: true),
+            // to enable saving comments in the tokenizer use the following line
+            // Evaluator(regex: ".*", generator: { (r: String) in .Comment(r.trim()) }, pop: true)
+            Evaluator(regex: ".*", generator: { _ in nil }, pop: true)
+        ]
+    }
+
+    private func stringEvaluators() -> [Evaluator] {
+        return [
+            Evaluator(regex: "\"", generator: { _ in nil }, pop: true),
+            Evaluator(regex: "([\\u0020-\\u0021\\u0023-\\u005B\\u005D-\\uFFFF]|\\\\\"|\\\\)+",
+                generator: { (r: String) in .Identifier(try r.replaceEscapeSequences()) })
+        ]
+    }
+
+    private func literalStringEvaluators() -> [Evaluator] {
+        return [
+            Evaluator(regex: "'", generator: { _ in nil }, pop: true),
+            Evaluator(regex: "([\\u0020-\\u0026\\u0028-\\uFFFF])+",
+                generator: { (r: String) in .Identifier(r) })
+        ]
+    }
+
+    private func multiLineStringEvaluators() -> [Evaluator] {
+        let validUnicodeChars = "\\u0020-\\u0021\\u0023-\\uFFFF"
+        return [
+            Evaluator(regex: "\"\"\"", generator: { _ in nil }, pop: true),
+            // Note: Does not allow multi-line strings that end with double qoutes.
+            // This is a common limitation of a variety of parsers I have tested
+            Evaluator(regex: "([\n" + validUnicodeChars + "]\"?\"?)*[\n" + validUnicodeChars + "]+",
+                generator: {
+                    (r: String) in
+                        .Identifier(try r.trim().stripLineContinuation().replaceEscapeSequences())
+                }, multiline: true)
+        ]
+    }
+
+    private func multiLineStringLiteralEvaluators() -> [Evaluator] {
+        let validUnicodeChars = "\n\\u0020-\\u0026\\u0028-\\uFFFF"
+        return [
+            Evaluator(regex: "'''", generator: { _ in nil }, pop: true),
+            Evaluator(regex: "([" + validUnicodeChars + "]'?'?)*[" + validUnicodeChars + "]+",
+                generator: { (r: String) in .Identifier(r.trim()) }, multiline: true)
+        ]
+    }
+
+    private func tableNameEvaluators() -> [Evaluator] {
+        let tableErrorStr = "Invalid table name declaration"
+        return [
+            Evaluator(regex: "\"", generator: { _ in nil }, push: ["string"]),
+            Evaluator(regex: "'", generator: { _ in nil }, push: ["literalString"]),
+            Evaluator(regex: "\\.", generator: { _ in .TableSep }),
+            // opening [ are prohibited directly within a table declaration
+            Evaluator(regex: "\\[", generator: { _ in throw TomlError.SyntaxError(tableErrorStr) }),
+            // hashes are prohibited directly within a table declaration
+            Evaluator(regex: "#", generator: { _ in throw TomlError.SyntaxError(tableErrorStr) }),
+            Evaluator(regex: "[A-Za-z0-9_-]+", generator: { (r: String) in .Identifier(r) }),
+            Evaluator(regex: "\\]\\]", generator: { _ in .TableArrayEnd }, pop: true),
+            Evaluator(regex: "\\]", generator: { _ in .TableEnd }, pop: true),
+        ]
+    }
+
+    private func tableArrayEvaluators() -> [Evaluator] {
+        let tableErrorStr = "Invalid table name declaration"
+        return [
+            Evaluator(regex: "\"", generator: { _ in nil }, push: ["string"]),
+            Evaluator(regex: "'", generator: { _ in nil }, push: ["literalString"]),
+            Evaluator(regex: "\\.", generator: { _ in .TableSep }),
+            // opening [ are prohibited directly within a table declaration
+            Evaluator(regex: "\\[", generator: { _ in throw TomlError.SyntaxError(tableErrorStr) }),
+            // hashes are prohibited directly within a table declaration
+            Evaluator(regex: "#", generator: { _ in throw TomlError.SyntaxError(tableErrorStr) }),
+            Evaluator(regex: "[A-Za-z0-9_-]+", generator: { (r: String) in .Identifier(r) }),
+            Evaluator(regex: "\\]\\]", generator: { _ in .TableArrayEnd }, pop: true),
+        ]
+    }
+
+    private func dateValueEvaluators() -> [Evaluator] {
+        let dateTimeStr = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"
+        return [
+            // Dates, RFC 3339 w/ fractional seconds and time offset
+            Evaluator(regex: dateTimeStr + ".\\d+(Z|z|[-\\+]\\d{2}:\\d{2})", generator: {
+                (r: String) in
+                    if let date = Date(rfc3339String: r) {
+                        return Token.DateTime(date)
+                    } else {
+                        throw TomlError.InvalidDateFormat("####-##-##T##:##:##.###+/-##:## (\(r))")
+                    }
+            }, pop: true),
+            // RFC 3339 w/o fractional seconds and time offset
+            Evaluator(regex: dateTimeStr + "(Z|z|[-\\+]\\d{2}:\\d{2})", generator: {
+                (r: String) in
+                    if let date = Date(rfc3339String: r, fractionalSeconds: false) {
+                        return Token.DateTime(date)
+                    } else {
+                        throw TomlError.InvalidDateFormat("####-##-##T##:##:##+/-##:## (\(r))")
+                    }
+            }, pop: true),
+            // Dates, RFC 3339 w/ fractional seconds and w/o time offset
+            Evaluator(regex: dateTimeStr + ".\\d+", generator: { (r: String) in
+                if let date = Date(rfc3339String: r, localTime: true) {
+                    return Token.DateTime(date)
+                } else {
+                    throw TomlError.InvalidDateFormat("####-##-##T##:##:##.### (\(r))")
+                }
+            }, pop: true),
+            // Dates, RFC 3339 w/o fractional seconds and w/o time offset
+            Evaluator(regex: dateTimeStr, generator: { (r: String) in
+                if let date = Date(rfc3339String: r, fractionalSeconds: false, localTime: true) {
+                    return Token.DateTime(date)
+                } else {
+                    throw TomlError.InvalidDateFormat("####-##-##T##:##:## (\(r))")
+                }
+            }, pop: true),
+            // Date only
+            Evaluator(regex: "\\d{4}-\\d{2}-\\d{2}", generator: { (r: String) in
+                if let date = Date(rfc3339String: r + "T00:00:00.0", localTime: true) {
+                    return Token.DateTime(date)
+                } else {
+                    throw TomlError.InvalidDateFormat("####-##-## (\(r))")
+                }
+            }, pop: true)
+        ]
+    }
+
+    private func stringValueEvaluators() -> [Evaluator] {
+        return [
+            // Multi-line string values (must come before single-line test)
+            // Special case, empty multi-line string
+            Evaluator(regex: "\"\"\"\"\"\"", generator: {_ in .Identifier("") }, pop: true),
+            Evaluator(regex: "\"\"\"", generator: { _ in nil },
+                push: ["multilineString"], pop: true),
+            // Multi-line literal string values (must come before single-line test)
+            Evaluator(regex: "'''", generator: { _ in nil },
+                push: ["multilineLiteralString"], pop: true),
+            // Special case, empty multi-line string literal
+            Evaluator(regex: "''''''", generator: { _ in .Identifier("") },
+                push: ["multilineLiteralString"], pop: true),
+            // empty single line strings
+            Evaluator(regex: "\"\"", generator: { _ in .Identifier("") }, pop: true),
+            Evaluator(regex: "''", generator: { _ in .Identifier("") }, pop: true),
+            // String values
+            Evaluator(regex: "\"", generator: { _ in nil }, push: ["string"], pop: true),
+            // Literal string values
+            Evaluator(regex: "'", generator: { _ in nil }, push: ["literalString"], pop: true),
+        ]
+    }
+
+    private func doubleValueEvaluators() -> [Evaluator] {
+        let generator: TokenGenerator = { (val: String) in .DoubleNumber(Double(val)!) }
+        return [
+            // Double values with exponent
+            Evaluator(regex: "[-\\+]?[0-9]+(\\.[0-9]+)?[eE][-\\+]?[0-9]+",
+                generator: generator, pop:true),
+            // Double values no exponent
+            Evaluator(regex: "[-\\+]?[0-9]+\\.[0-9]+", generator: generator, pop: true),
+        ]
+    }
+
+    private func intValueEvaluators() -> [Evaluator] {
+        return [
+            // Integer values
+            Evaluator(regex: "[-\\+]?[0-9]+",
+                generator: { (r: String) in .IntegerNumber(Int(r)!) }, pop: true),
+        ]
+    }
+
+    private func booleanValueEvaluators() -> [Evaluator] {
+        return [
+            // Boolean values
+            Evaluator(regex: "true", generator: { (r: String) in .Boolean(true) }, pop: true),
+            Evaluator(regex: "false", generator: { (r: String) in .Boolean(false) }, pop: true),
+        ]
+    }
+
+    private func whitespaceValueEvaluators() -> [Evaluator] {
+        return [
+            // Ignore white-space
+            Evaluator(regex: "[ \t]", generator: { _ in nil }),
+        ]
+    }
+
+    private func arrayValueEvaluators() -> [Evaluator] {
+        return [
+            // Arrays
+            Evaluator(regex: "\\[", generator: {
+                _ in .ArrayBegin
+            }, push: ["array", "array"], pop: true),
+        ]
+    }
+
+    private func inlineTableValueEvaluators() -> [Evaluator] {
+        return [
+            // Inline tables
+            Evaluator(regex: "\\{", generator: {
+                _ in .InlineTableBegin
+            }, push: ["inlineTable"], pop: true),
+        ]
+    }
+
+    private func valueEvaluators() -> [Evaluator] {
+        let typeEvaluators = stringValueEvaluators() + dateValueEvaluators() +
+            doubleValueEvaluators() + intValueEvaluators() + booleanValueEvaluators()
+
+        return whitespaceValueEvaluators() + arrayValueEvaluators() +
+            inlineTableValueEvaluators() + typeEvaluators
+    }
+
+    private func arrayEvaluators() -> [Evaluator] {
+        return [
+            // Ignore white-space
+            Evaluator(regex: "[ \n\t]", generator: { _ in nil }),
+
+            // Comments
+            Evaluator(regex: "#", generator: { _ in nil }, push: ["comment"]),
+
+            // Arrays
+            Evaluator(regex: "\\[", generator: { _ in .ArrayBegin }, push: ["array"]),
+            Evaluator(regex: "\\]", generator: { _ in .ArrayEnd }, pop: true),
+            Evaluator(regex: ",", generator: { _ in nil }, push: ["array"]),
+        ] + valueEvaluators()
+    }
+
+    private func stringKeyEvaluator() -> [Evaluator] {
+        let validUnicodeChars = "\\u0020-\\u0021\\u0023-\\u005B\\u005D-\\uFFFF"
+        return [
+            // bare key
+            Evaluator(regex: "[a-zA-Z0-9_-]+[ \t]*=",
+                generator: {
+                    (r: String) in
+                        .Key(String(r[..<r.index(r.endIndex, offsetBy:-1)]).trim())
+                },
+                push: ["value"]),
+            // string key
+            Evaluator(regex: "\"([" + validUnicodeChars + "]|\\\\\"|\\\\)+\"[ \t]*=",
+                generator: {
+                    (r: String) in
+                        .Key(try trimStringIdentifier(r, "\"").replaceEscapeSequences())
+                },
+                push: ["value"]),
+            // literal string key
+            Evaluator(regex: "'([\\u0020-\\u0026\\u0028-\\uFFFF])+'[ \t]*=",
+                generator: { (r: String) in .Key(trimStringIdentifier(r, "'")) },
+                push: ["value"]),
+        ]
+    }
+
+    private func inlineTableEvaluators() -> [Evaluator] {
+        return [
+            // Ignore white-space and commas
+            Evaluator(regex: "[ \t,]", generator: { _ in nil }),
+            // inline-table
+            Evaluator(regex: "\\{", generator: { _ in .InlineTableBegin }, push: ["inlineTable"]),
+            Evaluator(regex: "\\}", generator: { _ in .InlineTableEnd }, pop: true),
+        ] + stringKeyEvaluator()
+    }
+
+    private func rootEvaluators() -> [Evaluator] {
+        return [
+            // Ignore white-space
+            Evaluator(regex: "[ \t\r\n]", generator: { _ in nil }),
+            // Comments
+            Evaluator(regex: "#", generator: { _ in nil }, push: ["comment"]),
+        ] + stringKeyEvaluator() + [
+            // Array of tables (must come before table)
+            Evaluator(regex: "\\[\\[", generator: { _ in .TableArrayBegin }, push: ["tableArray"]),
+            // Tables
+            Evaluator(regex: "\\[", generator: { _ in .TableBegin }, push: ["tableName"]),
+        ]
+    }
+}

--- a/PotatsoLibrary/Toml/Helpers.swift
+++ b/PotatsoLibrary/Toml/Helpers.swift
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+class ArrayWrapper: SetValueProtocol {
+    var array: [Any]
+
+    init(array: [Any]) {
+        self.array = array
+    }
+
+    public func set(value: Any, for: [String]) {
+        array.append(value)
+    }
+}
+
+/**
+    Utility function to cast an array to a given type or throw an error
+
+    - Parameter array: Input array to cast to type T
+    - Parameter out: Array to store result in
+
+    - Throws: `TomlError.MixedArrayType` if array cannot be cast to appropriate type
+*/
+func checkAndSetArray<T: SetValueProtocol>(check: [Any], key: [String], out: inout T) throws {
+    // allow empty arrays
+    if check.isEmpty {
+        out.set(value: check, for: key)
+        return
+    }
+
+    // convert array to proper type
+    switch check[0] {
+        case is Int:
+            if let typedArray = check as? [Int] {
+                out.set(value: typedArray, for: key)
+            } else {
+                throw TomlError.MixedArrayType("Int")
+            }
+        case is Double:
+            if let typedArray = check as? [Double] {
+                out.set(value: typedArray, for: key)
+            } else {
+                throw TomlError.MixedArrayType("Double")
+            }
+        case is String:
+            if let typedArray = check as? [String] {
+                out.set(value: typedArray, for: key)
+            } else {
+                throw TomlError.MixedArrayType("String")
+            }
+        case is Bool:
+            if let typedArray = check as? [Bool] {
+                out.set(value: typedArray, for: key)
+            } else {
+                throw TomlError.MixedArrayType("Bool")
+            }
+        case is Date:
+            if let typedArray = check as? [Date] {
+                out.set(value: typedArray, for: key)
+            } else {
+                throw TomlError.MixedArrayType("Date")
+            }
+        default:
+            // array of arrays leave as any
+            out.set(value: check, for: key)
+    }
+}
+
+/**
+    Utility for trimming string identifiers in key/value pairs
+*/
+func trimStringIdentifier(_ input: String, _ quote: String = "\"") -> String {
+    let pattern = quote + "(.+)" + quote + "[ \t]*="
+    let regex = try! NSRegularExpression(pattern: pattern, options: [])
+    let matches = regex.matches(in: input, options: [],
+        range: NSMakeRange(0, input.utf16.count))
+    let nss = NSString(string: input)
+    return nss.substring(with: matches[0].range(at: 1))
+}
+
+func getKeyPathFromTable(tokens: [Token]) -> [String] {
+    var subKeyPath = [String]()
+    subKeyPathLoop: for token in tokens {
+        switch token {
+            case .Identifier(let val):
+                subKeyPath.append(val)
+            case .TableSep, .TableArrayBegin, .TableBegin:
+                continue
+            default:
+                break subKeyPathLoop
+        }
+    }
+
+    return subKeyPath
+}
+
+func consumeTableIdentifierTokens(tableTokens: inout [Token], tokens: inout [Token]) {
+    while !tokens.isEmpty {
+        let nestedToken = tokens[0]
+        tableTokens.append(nestedToken)
+        tokens.remove(at: 0)
+        if case .TableEnd = nestedToken {
+            break
+        } else if case .TableArrayEnd = nestedToken {
+            break
+        }
+    }
+}
+
+func getTableTokens(keyPath: [String], tokens: inout [Token]) -> [Token] {
+    var tableTokens = [Token]()
+    nestedTableLoop: while tokens.count > 0 {
+        let tableToken = tokens[0]
+
+        // need to include sub tables
+        switch tableToken {
+            case .TableBegin, .TableArrayBegin:
+                // get the key path of the new table
+                let subKeyPath = getKeyPathFromTable(tokens: tokens)
+
+                // If the new table is nested within the current one
+                // include it, otherwise we are finished.
+                if subKeyPath.count == 1 {
+                    // top-level - break
+                    break nestedTableLoop
+                }
+
+                if subKeyPath[0] != keyPath[0] {
+                    // nested table but not part of this table group
+                    break nestedTableLoop
+                }
+
+                // this table should be included because it's a
+                // nested table
+
+                // .TableBegin || .TableArrayBegin
+                tokens.remove(at: 0)
+                tableTokens.append(tableToken)
+
+                // skip first name
+                tokens.remove(at: 0) // Identifier
+                tokens.remove(at: 0) // .TableSep
+
+                consumeTableIdentifierTokens(tableTokens: &tableTokens, tokens: &tokens)
+            default:
+                tokens.remove(at: 0)
+                tableTokens.append(tableToken)
+        }
+    }
+
+    return tableTokens
+}
+
+func extractTableTokens(tokens: inout [Token], inline: Bool = false) -> [Token] {
+    var tableTokens = [Token]()
+    while !tokens.isEmpty {
+        let tableToken = tokens[0]
+
+        if inline {
+            tokens.remove(at: 0)
+        }
+
+        if case .InlineTableEnd = tableToken {
+            if inline {
+                break
+            }
+        } else if case .TableBegin = tableToken {
+            break
+        } else if case .TableArrayBegin = tableToken {
+            break
+        }
+
+        if !inline {
+            tokens.remove(at: 0)
+        }
+
+        tableTokens.append(tableToken)
+    }
+
+    return tableTokens
+}

--- a/PotatsoLibrary/Toml/Lexer.swift
+++ b/PotatsoLibrary/Toml/Lexer.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/**
+    Convert an input string of TOML to a stream of tokens
+*/
+class Lexer {
+    let input: String
+    var grammar: [String: [Evaluator]]
+
+    init(input: String, grammar: [String: [Evaluator]]) {
+        self.input = input
+        self.grammar = grammar
+    }
+
+    func tokenize() throws -> [Token] {
+        var tokens = [Token]()
+        var content = input
+        var stack = [String]()
+
+        stack.append("root")
+
+        while content.count > 0 {
+            var matched = false
+
+            // check content against evaluators to produce tokens
+            for evaluator in grammar[stack.last!]! {
+                if let e = try evaluator.evaluate(content) {
+                    if let t = e.token {
+                        tokens.append(t)
+                    }
+
+                    // should we pop the stack?
+                    if evaluator.pop {
+                        stack.removeLast()
+                    }
+
+                    // should we push onto the stack?
+                    if let pushItmes = evaluator.push {
+                        stack = stack + pushItmes
+                    }
+                    
+                    content = String(content[e.index...])
+                    matched = true
+                    break
+                }
+            }
+
+            if !matched {
+                throw TomlError.SyntaxError(content)
+            }
+        }
+        return tokens
+    }
+    
+}

--- a/PotatsoLibrary/Toml/Parser.swift
+++ b/PotatsoLibrary/Toml/Parser.swift
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+// MARK: Parse
+
+class Parser {
+    var keyPath: [String] = []
+    var currentKey = "."
+    var declaredTables = Set<String>()
+    var toml: Toml = Toml()
+
+    // MARK: Initializers
+
+    convenience init(toml: Toml) {
+        self.init()
+        self.toml = toml
+    }
+
+    // MARK: Parsing
+
+    public func parse(string: String) throws {
+        // Convert input into tokens
+        let lexer = Lexer(input: string, grammar: Grammar().grammar)
+        let tokens = try lexer.tokenize()
+        try parse(tokens: tokens)
+    }
+
+    /**
+        Parse a TOML token stream construct a dictionary.
+
+        - Parameter tokens: Token stream describing a TOML data structure
+    */
+    private func parse(tokens: [Token]) throws {
+        // A dispatch table for parsing TOML tables
+        let TokenMap: [Token: (Token, inout [Token]) throws -> ()] = [
+            .Identifier("1"): setValue,
+            .IntegerNumber(1): setValue,
+            .DoubleNumber(1.0): setValue,
+            .Boolean(true): setValue,
+            .DateTime(Date()): setValue,
+            .TableBegin: setTable,
+            .ArrayBegin: setArray,
+            .TableArrayBegin: setTableArray,
+            .InlineTableBegin: setInlineTable
+        ]
+
+        // Convert tokens to values in the Toml
+        var myTokens = tokens
+
+        while !myTokens.isEmpty {
+            let token = myTokens.remove(at: 0)
+            if case .Key(let val) = token {
+                currentKey = val
+            } else {
+                try TokenMap[token]!(token, &myTokens)
+            }
+        }
+    }
+
+    /**
+        Given a TOML token stream construct an array.
+
+        - Parameter tokens: Token stream describing array
+
+        - Returns: Array populated with values from token stream
+    */
+    private func parse(tokens: inout [Token]) throws -> [Any] {
+        var array: [Any] = [Any]()
+
+        while !tokens.isEmpty {
+            let token = tokens.remove(at: 0)
+            switch token {
+                case .Identifier(let val):
+                    array.append(val)
+                case .IntegerNumber(let val):
+                    array.append(val)
+                case .DoubleNumber(let val):
+                    array.append(val)
+                case .Boolean(let val):
+                    array.append(val)
+                case .DateTime(let val):
+                    array.append(val)
+                case .InlineTableBegin:
+                    array.append(try processInlineTable(tokens: &tokens))
+                case .ArrayBegin:
+                    var wrap = ArrayWrapper(array: array)
+                    try checkAndSetArray(check: parse(tokens: &tokens), key: [""], out: &wrap)
+                    array = wrap.array
+                default:
+                    return array
+            }
+        }
+
+        return array
+    }
+
+    private func processInlineTable(tokens: inout [Token]) throws -> Toml {
+        let tableTokens = extractTableTokens(tokens: &tokens, inline: true)
+        let tableParser = Parser()
+        try tableParser.parse(tokens: tableTokens)
+        return tableParser.toml
+    }
+
+    /**
+        Given a value token set its value in the `table`
+
+        - Parameter currToken: A value token that is currently being parsed
+        - Parameter tokens: Array of remaining tokens in the stream
+    */
+    private func setValue(currToken: Token, tokens: inout [Token]) throws {
+        var key = keyPath
+        key.append(currentKey)
+
+        if toml.hasKey(key: key) {
+            throw TomlError.DuplicateKey(String(describing: key))
+        }
+
+        toml.set(value: currToken.value as Any, for: key)
+    }
+
+    /**
+        Given a table extract all associated tokens from the stream and create
+        a new dictionary.
+
+        - Parameter currToken: A `Token.TableBegin` token
+        - Parameter table: Parent table to save resulting table to
+    */
+    private func setTable(currToken: Token, tokens: inout [Token]) throws {
+        var tableExists = false
+        var emptyTableSep = false
+        // clear out the keyPath
+        keyPath.removeAll()
+
+        while !tokens.isEmpty {
+            let subToken = tokens.remove(at: 0)
+            if case .TableEnd = subToken {
+                if keyPath.count < 1 {
+                    throw TomlError.SyntaxError("Table name must not be blank")
+                }
+
+                let keyPathStr = String(describing: keyPath)
+                if toml.hasKey(key: keyPath, includeTables: false) || declaredTables.contains(keyPathStr) {
+                    throw TomlError.DuplicateKey(String(describing: keyPath))
+                }
+
+                declaredTables.insert(keyPathStr)
+                let tableTokens = extractTableTokens(tokens: &tokens)
+                try parse(tokens: tableTokens)
+                tableExists = true
+                break
+            } else if case .TableSep = subToken {
+                if emptyTableSep {
+                    throw TomlError.SyntaxError("Must not have un-named implicit tables")
+                }
+                emptyTableSep = true
+            } else if case .Identifier(let val) = subToken {
+                emptyTableSep = false
+                keyPath.append(val)
+                toml.setTable(key: keyPath)
+            }
+        }
+
+        if !tableExists {
+            throw TomlError.SyntaxError("Table must contain at least a closing bracket")
+        }
+    }
+
+    private func setTableArray(currToken: Token, tokens: inout [Token]) throws {
+        // clear out the keyPath
+        keyPath.removeAll()
+
+        tableLoop: while !tokens.isEmpty {
+            let subToken = tokens.remove(at: 0)
+            if case .TableArrayEnd = subToken {
+                if keyPath.count < 1 {
+                    throw TomlError.SyntaxError("Table array name must not be blank")
+                }
+
+                let tableTokens = getTableTokens(keyPath: keyPath, tokens: &tokens)
+
+                if toml.hasKey(key: keyPath) {
+                    var arr: [Toml] = toml.array(keyPath)!
+                    let tableParser = Parser()
+                    try tableParser.parse(tokens: tableTokens)
+                    arr.append(tableParser.toml)
+                    toml.set(value: arr, for: keyPath)
+                } else {
+                    let tableParser = Parser()
+                    try tableParser.parse(tokens: tableTokens)
+                    toml.set(value: [tableParser.toml], for: keyPath)
+                }
+                break tableLoop
+            } else if case .Identifier(let val) = subToken {
+                keyPath.append(val)
+            }
+        }
+    }
+
+    /**
+        Given an inline table extract all associated tokens from the stream
+        and create a new dictionary.
+
+        - Parameter currToken: A `Token.InlineTableBegin` token
+        - Parameter table: Parent table to save resulting inline table to
+    */
+    private func setInlineTable(currToken: Token, tokens: inout [Token]) throws {
+        keyPath.append(currentKey)
+
+        let tableTokens = extractTableTokens(tokens: &tokens, inline: true)
+        try parse(tokens: tableTokens)
+
+        toml.setTable(key: keyPath)
+
+        // This was an inline table so remove from keyPath
+        keyPath.removeLast()
+    }
+
+    /**
+        Given an array save it to the parent table
+
+        - Parameter currToken: A `Token.ArrayBegin` token
+        - Parameter table: Parent table to save resulting inline table to
+    */
+    private func setArray(currToken: Token, tokens: inout [Token]) throws {
+        let arr: [Any] = try parse(tokens: &tokens)
+
+        var myKeyPath = keyPath
+        myKeyPath.append(currentKey)
+
+        // allow empty arrays
+        if arr.isEmpty {
+            toml.set(value: arr, for: myKeyPath)
+            return
+        }
+
+        try checkAndSetArray(check: arr, key: myKeyPath, out: &toml)
+    }
+}

--- a/PotatsoLibrary/Toml/Path.swift
+++ b/PotatsoLibrary/Toml/Path.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+    Abstraction for TOML key paths
+*/
+public struct Path: Hashable, Equatable {
+    internal(set) public var components: [String]
+
+    init(_ components: [String]) {
+        self.components = components
+    }
+
+    func begins(with: [String]) -> Bool {
+        if with.count > components.count {
+            return false
+        }
+
+        for x in with.indices {
+            if components[x] != with[x] {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    public var hashValue: Int {
+        return components.reduce(0, { $0 ^ $1.hashValue })
+    }
+
+    public static func == (lhs: Path, rhs: Path) -> Bool {
+        return lhs.components == rhs.components
+    }
+
+    static func + (lhs: Path, rhs: Path) -> Path {
+        return Path(lhs.components + rhs.components)
+    }
+}

--- a/PotatsoLibrary/Toml/Regex.swift
+++ b/PotatsoLibrary/Toml/Regex.swift
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+var expressions = [String: NSRegularExpression]()
+
+extension String {
+    func match(_ regex: String, options: NSRegularExpression.Options = []) -> String? {
+        let expression: NSRegularExpression
+        
+        if let cachedRegexp = expressions[regex] {
+            expression = cachedRegexp
+        } else {
+            expression = try! NSRegularExpression(pattern: "^\(regex)", options: options)
+            expressions[regex] = expression
+        }
+        
+        let range = expression.rangeOfFirstMatch(in: self, options: [],
+            range: NSMakeRange(0, self.count))
+        if range.location != NSNotFound {
+            return NSString(string: self).substring(with: range)
+        }
+        return nil
+    }
+}

--- a/PotatsoLibrary/Toml/Serialize.swift
+++ b/PotatsoLibrary/Toml/Serialize.swift
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/**
+    Get list of top level keys and optionally sort
+*/
+private func filterKeys(keys: Set<Path>) -> [String] {
+    var myKeys = keys.filter({ $0.components.count == 1}).map({ $0.components.first! })
+    myKeys.sort()
+    return myKeys
+}
+
+/**
+    Serialize all keys
+*/
+private func serializeKeys(toml: Toml) -> [String] {
+    var result: [String] = []
+
+    // serialize all key/value pairs at the base level
+    // only top level keys should be serialized at this time
+    // lower levels will be serialized by subsequent calls to this
+    // function
+    let myKeys = filterKeys(keys: toml.keyNames)
+
+    for key in myKeys {
+        result.append("\(quoted(key)) = \(toml.valueDescription([key])!)")
+    }
+
+    return result
+}
+
+/**
+    Serialize all tables
+*/
+private func serializeTable(toml: Toml) -> [String] {
+    var result: [String] = []
+
+    // serialize each table
+    let tableNames = filterKeys(keys: toml.tableNames)
+
+    for tableName in tableNames {
+        let table = toml.table(tableName)!
+
+        // get table title
+        var titleParts = [tableName]
+        if let prefixPath = toml.prefixPath {
+            titleParts = prefixPath.components + [tableName]
+        }
+        let title = titleParts.map(quoted).joined(separator: ".")
+
+        // get key value pairs for table
+        let tableString = serializeKeys(toml: table).joined(separator: "\n")
+
+        // if it's not an an empty table, add it
+        if !tableString.isEmpty {
+            result.append("[\(title)]\n" + tableString)
+        }
+
+        result += serializeTable(toml: table)
+    }
+
+    return result
+}
+
+/**
+    Serialize inline table
+ */
+func serializeInlineTable(toml: Toml) -> String {
+    let keys = serializeKeys(toml: toml)
+    var tables: [String] = []
+    for (_, table) in toml.tables() {
+        tables.append(serializeInlineTable(toml: table))
+    }
+    let result = (keys + tables).joined(separator: ", ")
+    return "{\(result)}"
+}
+
+/**
+    Serialize array of tables
+*/
+func serializeArrayOfTables(tables: [Toml]) -> String {
+    var result: [String] = []
+    for table in tables {
+        result.append(serializeInlineTable(toml: table))
+    }
+    return "[\(result.joined(separator: ",\n  "))]"
+}
+
+/**
+    Serialize a toml object to a string.
+
+    Note: If the toml object was constructed from an existing TOML string
+    then the string returned by this function will parse to an identical
+    hashmap; however, it may not be an identical string.
+
+    In particular, the resulting string will have the following properties:
+
+        * inline tables will no longer be inline
+        * arrays of tables will be inline
+        * strings will always be single line unicode strings with the minimal
+          number of characters escaped
+        * no comments will appear in the document
+        * whitespace will be standardized to a single space before and after the
+          '=' symbol in key/value pairs and each new table will have a preceding
+          blank line
+        * key pairs and tables will be output in alpha-numeric order
+
+    - Parameter toml: Toml object to serialize
+
+    - Returns: The Toml object serialized to Toml
+*/
+func serialize(toml: Toml) -> String {
+    var result = ""
+
+    result += serializeKeys(toml: toml).joined(separator: "\n")
+    result += "\n\n" + serializeTable(toml: toml).joined(separator: "\n\n")
+
+    return result.trim()
+}

--- a/PotatsoLibrary/Toml/String.swift
+++ b/PotatsoLibrary/Toml/String.swift
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+func getUnicodeChar(unicode: String) throws -> String {
+    // check if it's a valid character
+    let code = Int(strtoul(unicode, nil, 16))
+
+    if code < 0x0 || (code > 0xD7FF && code < 0xE000) || code > 0x10FFFF {
+        throw TomlError.InvalidUnicodeCharacter(code)
+    }
+
+    return String(describing: UnicodeScalar(code)!)
+}
+
+func checkEscape(char: Character, escape: inout Bool) throws -> (String, Int) {
+    var unicodeSize = -1
+    var s: String = ""
+
+    switch char {
+        case "n":
+            s = "\n"
+            escape = false
+        case "\\":
+            s = "\\"
+            escape = false
+        case "\"":
+            s = "\""
+            escape = false
+        case "f":
+            s = "\u{000C}"
+            escape = false
+        case "b":
+            s = "\u{0008}"
+            escape = false
+        case "t":
+            s = "\t"
+            escape = false
+        case "r":
+            s = "\r"
+            escape = false
+        case "u":
+            unicodeSize = 4
+        case "U":
+            unicodeSize = 8
+        default:
+            throw TomlError.InvalidEscapeSequence("\\" + String(describing: char))
+    }
+
+    return (s, unicodeSize)
+}
+
+extension String {
+    func trim() -> String {
+        return self.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines)
+    }
+
+    func stripLineContinuation() -> String {
+        var s = self
+        let regex = try! NSRegularExpression(pattern: "\\\\(\\s+)",
+            options: [.dotMatchesLineSeparators])
+        let matches = regex.matches(in: s, options: [],
+            range: NSMakeRange(0, s.utf16.count))
+        let nss = NSString(string: s)
+
+        for match in matches {
+            let m0 = nss.substring(with: match.range(at: 0))
+            s = s.replacingOccurrences(of: m0, with: "")
+        }
+
+        return s
+    }
+
+    func replaceEscapeSequences() throws -> String {
+        var s = "" // new string that is being constructed
+        var escape = false
+        var unicode = ""
+        var unicodeSize = -1
+
+        for char in self {
+            if escape {
+                if unicodeSize == 0 {
+                    s += try getUnicodeChar(unicode: unicode)
+                    s += String(describing: char)
+
+                    escape = false
+                    unicodeSize = -1
+                    unicode = ""
+                } else if unicodeSize > 0 {
+                    unicodeSize -= 1
+                    unicode += String(describing: char)
+                } else {
+                    let (newChar, size) = try checkEscape(char: char, escape: &escape)
+                    s += newChar
+                    unicodeSize = size
+                }
+            } else if char == "\\" {
+                escape = true
+            } else {
+                s += String(describing: char)
+            }
+        }
+
+        if unicodeSize == 0 {
+            s += try getUnicodeChar(unicode: unicode)
+        }
+
+        return s
+    }
+}
+
+// Mark: String related array extensions
+
+func quoted(_ value: String) -> String {
+    if let _ = value.match(".*[\\u0020-\\u002B\\u002E-\\u002F\\u003A-\\u0040" +
+        "\\u005B-\\u005E\\u0060\\u007B-\\uFFFF]+.*") {
+        return "\"\(value)\""
+    }
+
+    return value
+}
+
+/**
+    Escape the string according to the rules of a single line Toml string
+
+    - Parameters string: The string to escape
+
+    - Returns: Escaped version of the string
+*/
+func escape(string: String) -> String {
+    var result: String
+    let escapeMap = ["\n": "\\n", "\r": "\\r", "\t": "\\t", "\"": "\\\""]
+
+    // must escape \ first because it is the escape character
+    result = string.replacingOccurrences(of: "\\", with: "\\\\")
+    for (key, val) in escapeMap {
+        result = result.replacingOccurrences(of: key, with: val)
+    }
+
+    return result
+}

--- a/PotatsoLibrary/Toml/Tokens.swift
+++ b/PotatsoLibrary/Toml/Tokens.swift
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+enum Token: Hashable {
+    case Identifier(String)
+    case Key(String)
+    case IntegerNumber(Int)
+    case DoubleNumber(Double)
+    case Boolean(Bool)
+    case DateTime(Date)
+    case ArrayBegin
+    case ArrayEnd
+    case TableArrayBegin
+    case TableArrayEnd
+    case InlineTableBegin
+    case InlineTableEnd
+    case TableBegin
+    case TableSep
+    case TableEnd
+    case Comment(String)
+
+    var hashValue: Int {
+        switch self {
+        case .Identifier:
+            return 0
+        case .Key:
+            return 1
+        case .IntegerNumber:
+            return 2
+        case .DoubleNumber:
+            return 3
+        case .Boolean:
+            return 4
+        case .DateTime:
+            return 5
+        case .ArrayBegin:
+            return 6
+        case .ArrayEnd:
+            return 7
+        case .TableArrayBegin:
+            return 8
+        case .TableArrayEnd:
+            return 9
+        case .InlineTableBegin:
+            return 10
+        case .InlineTableEnd:
+            return 11
+        case .TableBegin:
+            return 12
+        case .TableSep:
+            return 13
+        case .TableEnd:
+            return 14
+        case .Comment:
+            return 15
+        }
+    }
+
+    var value : Any? {
+        switch self {
+        case .Identifier(let val):
+            return val
+        case .Key(let val):
+            return val
+        case .IntegerNumber(let val):
+            return val
+        case .DoubleNumber(let val):
+            return val
+        case .Boolean(let val):
+            return val
+        case .DateTime(let val):
+            return val
+        case .Comment(let val):
+            return val
+        default:
+            return nil
+        }
+    }
+    
+    static func == (lhs: Token, rhs: Token) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+    
+}
+
+typealias TokenGenerator = (String) throws -> Token?

--- a/PotatsoLibrary/Toml/Toml.swift
+++ b/PotatsoLibrary/Toml/Toml.swift
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2016-2018 JD Fergason
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/**
+    Error thrown when a TOML syntax error is encountered
+
+    - DuplicateKey: Document contains a duplicate key
+    - InvalidDateFormat: Date string is not a supported format
+    - InvalidEscapeSequence: Unsupported escape sequence used in string
+    - InvalidUnicodeCharacter: Non-existant unicode character specified
+    - MixedArrayType: Array is composed of multiple types, members must all be the same type
+    - SyntaxError: Document cannot be parsed due to a syntax error
+*/
+public enum TomlError: Error {
+    case DuplicateKey(String)
+    case InvalidDateFormat(String)
+    case InvalidEscapeSequence(String)
+    case InvalidUnicodeCharacter(Int)
+    case MixedArrayType(String)
+    case SyntaxError(String)
+}
+
+protocol SetValueProtocol {
+    mutating func set(value: Any, for key: [String])
+}
+
+/**
+    Data parsed from a TOML document
+*/
+public class Toml: CustomStringConvertible, SetValueProtocol {
+    private var data: [Path: Any]
+    private(set) public var keyNames: Set<Path>
+    private(set) public var prefixPath: Path?
+    private(set) public var tableNames: Set<Path>
+
+    public init() {
+        data = [Path: Any]()
+        keyNames = Set<Path>()
+        tableNames = Set<Path>()
+    }
+
+    /**
+        Read the specified TOML file from disk.
+
+        - Parameter contentsOfFile: Path of file to read
+        - Parameter encoding: Encoding of file
+
+        - Throws: `TomlError.SyntaxError` if the file is invalid
+        - Throws: `NSError` if the file does not exist
+
+        - Returns: A dictionary with parsed results
+    */
+    public convenience init(contentsOfFile path: String,
+        encoding: String.Encoding = String.Encoding.utf8) throws {
+        self.init()
+        let source = try String(contentsOfFile: path, encoding: encoding)
+        let parser = Parser(toml: self)
+        try parser.parse(string: source)
+    }
+
+    /**
+        Parse the string `withString` as TOML.
+
+        - Parameter withString: A string with TOML document
+
+        - Throws: `TomlError.SyntaxError` if the file is invalid
+
+        - Returns: A dictionary with parsed results
+    */
+    public convenience init(withString string: String) throws {
+        self.init()
+        let parser = Parser(toml: self)
+        try parser.parse(string: string)
+    }
+
+    /**
+        Create an empty Toml object with the specified prefix path
+
+        - Parameter prefixPath: The path to prefix all tables with
+    */
+    private convenience init(prefixPath: Path) {
+        self.init()
+        self.prefixPath = prefixPath
+    }
+
+    /**
+        Set the value for the the given key path
+
+        - Parameter key: Array of strings
+        - Parameter value: Value to set
+    */
+    public func set(value: Any, for key: [String]) {
+        let path = Path(key)
+        keyNames.insert(path)
+        data[path] = value
+    }
+
+    /**
+        Add a sub-table
+
+        - Parameter key: Array of strings indicating table path
+    */
+    public func setTable(key: [String]) {
+        tableNames.insert(Path(key))
+    }
+
+    /**
+        Check if the TOML document contains the specified key.
+
+        - Parameter key: Key path to check
+        - Parameter includeTables: Include tables and inline tables in key path check
+
+        - Returns: True if key exists; false otherwise
+    */
+    public func hasKey(key: [String], includeTables: Bool = true) -> Bool {
+        var keyExists = data[Path(key)] != nil
+        if includeTables {
+            keyExists = keyExists || hasTable(key)
+        }
+        return keyExists
+    }
+
+    /**
+        Check if the TOML document contains the specified key.
+
+        - Parameter key: Key path to check
+
+        - Returns: True if key exists; false otherwise
+    */
+    public func hasKey(_ key: String...) -> Bool {
+        return hasKey(key: key)
+    }
+
+    /**
+        Check if the TOML document contains the specified table.
+
+        - Parameter key: Key path to check
+
+        - Returns: True if table exists; false otherwise
+    */
+    public func hasTable(_ key: [String]) -> Bool {
+        return tableNames.contains(Path(key))
+    }
+
+    /**
+        Check if the TOML document contains the specified table.
+
+        - Parameter key: Key path to check
+
+        - Returns: True if key exists; false otherwise
+    */
+    public func hasTable(_ key: String...) -> Bool {
+        return hasTable(key)
+    }
+
+    /**
+        Get an array of type T from the TOML document
+
+        - Parameter path: Key path of array
+
+        - Returns: An array of type [T]
+    */
+    public func array<T>(_ path: [String]) -> [T]? {
+        if let val = data[Path(path)] {
+            return val as? [T]
+        }
+
+        return nil
+    }
+
+    /**
+        Get an array of type T from the TOML document
+
+        - Parameter path: Key path of array
+
+        - Returns: An array of type [T]
+    */
+    public func array<T>(_ path: String...) -> [T]? {
+        return array(path)
+    }
+
+    /**
+        Get a boolean value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: boolean value of key path
+    */
+    public func bool(_ path: [String]) -> Bool? {
+        return value(path)
+    }
+
+    /**
+        Get a boolean value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: boolean value of key path
+    */
+    public func bool(_ path: String...) -> Bool? {
+        return value(path)
+    }
+
+    /**
+        Get a date value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: date value of key path
+    */
+    public func date(_ path: [String]) -> Date? {
+        return value(path)
+    }
+
+    /**
+        Get a date value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: date value of key path
+    */
+    public func date(_ path: String...) -> Date? {
+        return value(path)
+    }
+
+    /**
+        Get a double value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: double value of key path
+    */
+    public func double(_ path: [String]) -> Double? {
+        return value(path)
+    }
+
+    /**
+        Get a double value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: double value of key path
+    */
+    public func double(_ path: String...) -> Double? {
+        return double(path)
+    }
+
+    /**
+        Get a int value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: int value of key path
+    */
+    public func int(_ path: [String]) -> Int? {
+        return value(path)
+    }
+
+    /**
+        Get a int value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: int value of key path
+    */
+    public func int(_ path: String...) -> Int? {
+        return value(path)
+    }
+
+    /**
+        Get a string value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: string value of key path
+    */
+    public func string(_ path: [String]) -> String? {
+        return value(path)
+    }
+
+    /**
+        Get a string value from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: string value of key path
+    */
+    public func string(_ path: String...) -> String? {
+        return value(path)
+    }
+
+    /**
+        Get a dictionary of all tables 1-level down from the given key
+        path.  To get all tables at the root level call with no parameters.
+
+        - Parameter parent: Root key path
+
+        - Returns: Dictionary of key names and tables
+    */
+    public func tables(_ parent: [String]) -> [String: Toml] {
+        var result = [String: Toml]()
+        for tableName in tableNames {
+            var tableParent = tableName
+            var myTableName = tableName
+            if let tablePrefix = prefixPath {
+                myTableName = tablePrefix + tableName
+            }
+
+            tableParent.components.removeLast()
+            if parent == tableParent.components {
+                // this is a table to include
+                result[myTableName.components.map(quoted).joined(separator: ".")] = table(from: tableName.components)
+            }
+        }
+        return result
+    }
+
+    /**
+        Get a dictionary of all tables 1-level down from the given key
+        path.  To get all tables at the root level call with no parameters.
+
+        - Parameter parent: Root key path
+
+        - Returns: Dictionary of key names and tables
+    */
+    public func tables(_ parent: String...) -> [String: Toml] {
+        return tables(parent)
+    }
+
+    /**
+        Return a TOML table that contains everything beneath the specified
+        path.
+
+        - Parameter from: Key path to create table from
+
+        - Returns: `Toml` table of all keys beneath the specified path
+    */
+    public func table(from path: [String]) -> Toml {
+        var fullTablePrefix = Path(path)
+        if let tablePrefix = prefixPath {
+            fullTablePrefix = tablePrefix + Path(path)
+        }
+
+        let constructedTable = Toml(prefixPath: fullTablePrefix)
+
+        // add values
+        for keyName in keyNames {
+            var keyArray = keyName.components
+            if keyName.begins(with: path) {
+                keyArray.removeSubrange(0..<path.count)
+                constructedTable.set(value: self.value(keyName.components)!, for: keyArray)
+            }
+        }
+
+        // add tables
+        for tableName in tableNames {
+            var tableArray = tableName.components
+            if tableName.begins(with: path) {
+                tableArray.removeSubrange(0..<path.count)
+                if !tableArray.isEmpty {
+                    constructedTable.setTable(key: tableArray)
+                }
+            }
+        }
+
+        return constructedTable
+    }
+
+    /**
+        Get a TOML table from the document
+
+        - Parameter path: Key path of value
+
+        - Returns: Table of name `path`
+    */
+    public func table(_ path: String...) -> Toml? {
+        return table(from: path)
+    }
+
+    /**
+        Get a value of type T from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: value of key path
+    */
+    public func value<T>(_ path: [String]) -> T? {
+        if let val = data[Path(path)] {
+            return val as? T
+        }
+
+        return nil
+    }
+
+    /**
+        Get a value of type T from the specified key path.
+
+        - Parameter path: Key path of value
+
+        - Returns: value of key path
+    */
+    public func value<T>(_ path: String...) throws -> T? {
+        return value(path)
+    }
+
+    /**
+        Get the value specified by path as a string
+
+        - Parameter path: Key path of value
+
+        - Returns: value of key path as a string
+    */
+    public func valueDescription(_ path: [String]) -> String? {
+        if let check = data[Path(path)] {
+            if let intVal = check as? Int {
+                return String(describing: intVal)
+            } else if let doubleVal = check as? Double {
+                return String(describing: doubleVal)
+            } else if let stringVal = check as? String {
+                return "\"\(escape(string: stringVal))\""
+            } else if let boolVal = check as? Bool {
+                return String(describing: boolVal)
+            } else if let dateVal = check as? Date {
+                return dateVal.rfc3339String()
+            } else if let tableArray = check as? [Toml] {
+                return serializeArrayOfTables(tables: tableArray)
+            }
+
+            return String(describing: check)
+        }
+
+        return nil
+    }
+
+    /**
+        Get a string representation of the TOML document
+
+        - Returns: String version of TOML document
+    */
+    public var description: String {
+        return serialize(toml: self)
+    }
+}


### PR DESCRIPTION
支持导入Potatso 2格式的配置文件，比如[这种](https://github.com/Hackl0us/SS-Rule-Snippet/blob/master/LAZY_RULES/Potatso2.pcf)。
偷懒通过源码导入了一个新的[第三方库](https://github.com/jdfergason/swift-toml)来解析TOML。

有需要可以看看。。